### PR TITLE
Update 0.9.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,6 @@
+channels:
+  melody_org: flask-update
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"
+  - "--error-overdepending"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,0 @@
-channels:
-  melody_org: flask-update
-build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"
-  - "--error-overdepending"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,12 +35,12 @@ test:
     - pip check
     # This has been changed due to the following error:
     # FAILED tests/test_trustme.py::test_pyopenssl_end_to_end - MemoryError: Cannot...
-    - pytest --cov trustme --cov-fail-under 98 # [win and linux]
+    - pytest #--cov trustme --cov-fail-under 98
     #-k "not test_pyopenssl_end_to_end"
   requires:
     - pip
     - pytest
-    - pytest-cov
+    #- pytest-cov
     - pyopenssl
     - service_identity
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,8 @@ test:
     - trustme
   commands:
     - pip check
+    # This has been changed due to the following error:
+    # FAILED tests/test_trustme.py::test_pyopenssl_end_to_end - MemoryError: Cannot...
     - pytest --cov trustme -k "not test_pyopenssl_end_to_end"
   requires:
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,14 +33,13 @@ test:
     - trustme
   commands:
     - pip check
-    # This has been changed due to the following error:
-    # FAILED tests/test_trustme.py::test_pyopenssl_end_to_end - MemoryError: Cannot...
-    - pytest #--cov trustme --cov-fail-under 98
-    #-k "not test_pyopenssl_end_to_end"
+    # test_pyopenssl_end_to_end does not work on osx-arm64:
+    # https://github.com/pyca/pyopenssl/issues/873
+    - pytest  # [not (osx and arm64)]
+    - pytest -k "not test_pyopenssl_end_to_end"  # [osx and arm64]
   requires:
     - pip
     - pytest
-    #- pytest-cov
     - pyopenssl
     - service_identity
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 5e07b23d70ceed64f3bb36ae4b9abc52354c16c98d45ab037bee2b5fbffe586c
 
 build:
-  skip: True  # [py<35]
+  skip: True  # [py<37]
   number: 0
   script: {{ PYTHON }} -m pip install . -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,8 +52,8 @@ about:
     - LICENSE.MIT
     - LICENSE.APACHE2
   license_family: MIT
-  dev_url: https://trustme.readthedocs.io
-  doc_url: https://github.com/python-trio/trustme/tree/v{{ version }}/docs
+  dev_url: https://github.com/python-trio/trustme
+  doc_url: https://trustme.readthedocs.io
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,16 +13,15 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv
-  noarch: python
 
 requirements:
   host:
     - pip
-    - python >=3.5
+    - python
   run:
     - cryptography
     - idna
-    - python >=3.5
+    - python
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "trustme" %}
-{% set version = "0.6.0" %}
+{% set version = "0.9.0" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 9dfb18b568729d0219f758cddca1a91bab59f62ca41ee0e8acce5e657ec97b6c
+  sha256: 5e07b23d70ceed64f3bb36ae4b9abc52354c16c98d45ab037bee2b5fbffe586c
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,8 @@ test:
     - pip check
     # This has been changed due to the following error:
     # FAILED tests/test_trustme.py::test_pyopenssl_end_to_end - MemoryError: Cannot...
-    - pytest --cov trustme -k "not test_pyopenssl_end_to_end"
+    - pytest --cov trustme --cov-fail-under 98 # [win and linux]
+    #-k "not test_pyopenssl_end_to_end"
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
   sha256: 5e07b23d70ceed64f3bb36ae4b9abc52354c16c98d45ab037bee2b5fbffe586c
 
 build:
+  skip: True  # [py<35]
   number: 0
   script: {{ PYTHON }} -m pip install . -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ test:
     - service_identity
 
 about:
-  home: https://github.com/python-trio/trustme
+  home: https://trustme.readthedocs.io/
   description: |
     trustme is a tiny Python package that does one thing: it gives you a fake certificate authority (CA) 
     that you can use to generate fake TLS certs to use in your tests.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,13 +43,17 @@ test:
 
 about:
   home: https://github.com/python-trio/trustme
+  description: |
+    trustme is a tiny Python package that does one thing: it gives you a fake certificate authority (CA) 
+    that you can use to generate fake TLS certs to use in your tests.
   summary: '#1 quality TLS certs while you wait, for the discerning tester'
   license: Apache-2.0 or MIT
   license_file:
     - LICENSE.MIT
     - LICENSE.APACHE2
-  doc_url: https://trustme.readthedocs.io
-  doc_source_url: https://github.com/python-trio/trustme/tree/v{{ version }}/docs
+  license_family: MIT
+  dev_url: https://trustme.readthedocs.io
+  doc_url: https://github.com/python-trio/trustme/tree/v{{ version }}/docs
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ test:
     - trustme
   commands:
     - pip check
-    - pytest --cov trustme --cov-fail-under 98
+    - pytest --cov trustme -k "not test_pyopenssl_end_to_end"
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,10 +18,12 @@ requirements:
   host:
     - pip
     - python
+    - setuptools
+    - wheel
   run:
+    - python
     - cryptography
     - idna
-    - python
 
 test:
   source_files:


### PR DESCRIPTION
Jira ticket: https://anaconda.atlassian.net/browse/PKG-705
Upstream repo: https://github.com/python-trio/trustme/tree/v0.9.0
Changelog: https://trustme.readthedocs.io/en/latest/#change-history

Line 36 - We are skipping test_pyopenssl_end_to_end due to the following error:

`FAILED tests/test_trustme.py::test_pyopenssl_end_to_end - MemoryError: Cannot...`